### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.18.12@sha256:de0eb0b3f2a47ba1eb89389859a9bd88b28e82f5826b6969ad604979713c2d4f
 
 # install packages required to run the tests
 RUN apk add --no-cache jq coreutils


### PR DESCRIPTION
This prevents rebuilds when there is no need and allows us to share base images across test runners.